### PR TITLE
fix folder opening too late

### DIFF
--- a/util/download.py
+++ b/util/download.py
@@ -2,8 +2,6 @@ import util.files as files
 
 
 def download():
-    files.make_input_output_folders()
-
     if files.has_package_json():
         files.package_json_parse()
 

--- a/util/menu.py
+++ b/util/menu.py
@@ -1,8 +1,10 @@
 import util.download as download
 from util.helper import menu_input
+from util.files import make_input_output_folders
 
 
 def menu():
+    make_input_output_folders()
     while True:
         user_choice = menu_input('Welcome to Package Installer',
                                  ['Download', 'Upload', 'Exit'])


### PR DESCRIPTION
Fixed a bug where make_input_output_folders was called each time you pressed download.

Fixed a bug where folders were only created after clicking download.